### PR TITLE
(Draft) Parse to TaylorModel1{TaylorN}

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 Flowstar_jll = "857d554b-2109-5851-8b71-fc429cd15c15"
 TaylorModels = "314ce334-5f6e-57ae-acf6-00b6e903104a"
+TypedPolynomials = "afbbf031-7a57-5f58-a1b9-b774a0fad08d"
 
 [compat]
 TaylorModels = "0.6"

--- a/examples/parsing.jl
+++ b/examples/parsing.jl
@@ -14,3 +14,10 @@ FS2 = FlowstarContinuousSolution(model)
 
 fp = flowpipe(FS2)
 tm = fp[end][1]  # final set, state 1
+
+## parse string into TaylorModel1{TaylorN{Interval{Float64}}, Float64}
+FS3 = parse(FlowstarContinuousSolution, S, Val(true))
+
+tm1 = FS3[end][1]
+eval_t = mid(domain(tm1))
+tm1(eval_t)


### PR DESCRIPTION
Parsing *.flow string using TypedPolynomials instead of TaylorN allows usage of `MultivariatePolynomials.coefficient` to generate the monomial list in `t` as `TaylorN{Interval}`